### PR TITLE
feat: enable observability

### DIFF
--- a/hack/run-helm-with-local-build.sh
+++ b/hack/run-helm-with-local-build.sh
@@ -55,7 +55,8 @@ helm upgrade --install sbomer-release "./$PLATFORM_DIR" \
     --create-namespace \
     --set global.includeKafka=true \
     --set global.includeApicurio=true \
-    --set global.includeApiGateway=true
+    --set global.includeApiGateway=true \
+    --set global.includeOtelLgtm=true
 
 helm upgrade --install errata-tool-handler "./helm/errata-tool-handler-chart" \
     --namespace $NAMESPACE \

--- a/helm/errata-tool-handler-chart/templates/deployment.yaml
+++ b/helm/errata-tool-handler-chart/templates/deployment.yaml
@@ -45,6 +45,12 @@ spec:
               containerPort: {{ .Values.service.port }}
               protocol: TCP
           env:
+            - name: QUARKUS_OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.config.otel.endpoint }}
+            - name: QUARKUS_OTEL_EXPORTER_OTLP_PROTOCOL
+              value: {{ .Values.config.otel.protocol }}
+            - name: QUARKUS_OTEL_RESOURCE_ATTRIBUTES
+              value: "service.name=sbomer-errata-tool-handler"
             - name: KAFKA_BOOTSTRAP_SERVERS
               value: {{ .Values.config.kafka.bootstrapServers | quote }}
             - name: SCHEMA_REGISTRY_URL

--- a/helm/errata-tool-handler-chart/values.yaml
+++ b/helm/errata-tool-handler-chart/values.yaml
@@ -15,6 +15,9 @@ image:
 
 # --- APPLICATION CONFIG ---
 config:
+  otel:
+    protocol: grpc
+    endpoint: "" # placeholder
   kafka:
     bootstrapServers: "kafka:9092"
     schemaRegistryUrl: "http://schema-registry:8080/apis/registry/v2"

--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,14 @@
             <artifactId>quarkus-smallrye-health</artifactId>
         </dependency>
         <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-opentelemetry</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-micrometer-registry-prometheus</artifactId>
+        </dependency>
+        <dependency>
             <groupId>io.cloudevents</groupId>
             <artifactId>cloudevents-kafka</artifactId>
             <version>4.0.1</version>

--- a/src/main/java/org/jboss/sbomer/handler/et/adapter/in/UmbAdvisoryHandler.java
+++ b/src/main/java/org/jboss/sbomer/handler/et/adapter/in/UmbAdvisoryHandler.java
@@ -11,6 +11,8 @@ import org.eclipse.microprofile.reactive.messaging.Message;
 import org.jboss.sbomer.handler.et.core.port.api.AdvisoryHandler;
 
 import dev.openfeature.sdk.Client;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
 import io.smallrye.reactive.messaging.amqp.IncomingAmqpMetadata;
 import io.smallrye.reactive.messaging.annotations.Blocking;
 import io.vertx.core.json.JsonObject;
@@ -67,6 +69,9 @@ public class UmbAdvisoryHandler {
             json = new JsonObject(payload);
         } catch (Exception e) {
             log.error("Failed to parse UMB message payload. Raw payload: {}", payload, e);
+            Span span = Span.current();
+            span.recordException(e);
+            span.setStatus(StatusCode.ERROR, e.getMessage());
             return message.ack();
         }
 

--- a/src/main/java/org/jboss/sbomer/handler/et/core/service/AdvisoryService.java
+++ b/src/main/java/org/jboss/sbomer/handler/et/core/service/AdvisoryService.java
@@ -19,6 +19,8 @@ import org.jboss.sbomer.handler.et.core.port.spi.Koji;
 import org.jboss.sbomer.handler.et.core.utility.FailureUtility;
 import org.jboss.sbomer.handler.et.core.utility.TsidUtility;
 
+import io.opentelemetry.instrumentation.annotations.SpanAttribute;
+import io.opentelemetry.instrumentation.annotations.WithSpan;
 import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.inject.Inject;
 import lombok.extern.slf4j.Slf4j;
@@ -48,8 +50,9 @@ public class AdvisoryService implements AdvisoryHandler {
         this.failureNotifier = failureNotifier;
     }
 
+    @WithSpan
     @Override
-    public GenerationRequest requestGenerations(String advisoryId) {
+    public GenerationRequest requestGenerations(@SpanAttribute("advisory.id") String advisoryId) {
         log.info("Handling advisory: {}...", advisoryId);
 
         try {
@@ -89,7 +92,7 @@ public class AdvisoryService implements AdvisoryHandler {
             log.error("Failed to handle advisory '{}' due to an unexpected error: {}", advisoryId, e.getMessage(), e);
             FailureSpec failure = FailureUtility.buildFailureSpecFromException(e);
             // Notify the failure (the source is null, no source event).
-            failureNotifier.notify(failure, null, null);
+            failureNotifier.notify(failure, advisoryId, null);
             throw new AdvisoryProcessingException("Failed to process advisory " + advisoryId, e);
         }
     }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,6 +3,16 @@
 #=======================================
 quarkus.log.level=INFO
 quarkus.log.category."org.jboss.sbomer".level=DEBUG
+quarkus.log.console.format=%d{HH:mm:ss,SSS} %-5p traceId=%X{traceId} parentId=%X{parentId} spanId=%X{spanId} [%c{3.}] (%t) %s%e mdc:[%X]%n
+
+#=======================================
+# OBSERVABILITY
+#=======================================
+quarkus.otel.enabled=true
+quarkus.otel.traces.enabled=true
+quarkus.otel.traces.sampler=always_on
+quarkus.otel.metrics.enabled=true
+quarkus.otel.logs.enabled=true
 
 #=======================================
 # APPLICATION


### PR DESCRIPTION
Add OTel dependencies.
Add OTel app config.
Add span details to K8s pod logs.
Add OTel helm config.
Add span error handling.
Add spans to meaningful business logic.
Made failure notification traceable in AdvisoryService.

Closes #51 